### PR TITLE
Fix default URL regex value  

### DIFF
--- a/sdk/core/azure-core-test/src/main/java/com/azure/core/test/utils/TestProxyUtils.java
+++ b/sdk/core/azure-core-test/src/main/java/com/azure/core/test/utils/TestProxyUtils.java
@@ -37,8 +37,7 @@ public class TestProxyUtils {
         "(?:<SecondaryKey>)(?<secret>.*)(?:</SecondaryKey>)"));
 
     private static final String URL_REGEX =
-        "^(?:https?:\\\\/\\\\/)?(?:[^@\\\\/\\\\n]+@)?(?:www\\\\.)?([^:\\\\/?\\\\n]+)";
-    private static final String URL_REDACTION_VALUE = "https://REDACTED";
+        "(?<=http://|https://)(?:[^@\\\\]+@)?(?:www\\\\.)?([^:\\\\/]+)";
     private static final List<String> HEADERS_TO_REDACT = new ArrayList<>(Arrays.asList("Ocp-Apim-Subscription-Key"));
     private static final String REDACTED_VALUE = "REDACTED";
 
@@ -149,7 +148,7 @@ public class TestProxyUtils {
     }
 
     private static TestProxySanitizer addDefaultUrlSanitizer() {
-        return new TestProxySanitizer(URL_REGEX, URL_REDACTION_VALUE, TestProxySanitizerType.URL);
+        return new TestProxySanitizer(URL_REGEX, REDACTED_VALUE, TestProxySanitizerType.URL);
     }
 
     private static List<TestProxySanitizer> addDefaultBodySanitizers() {

--- a/sdk/core/azure-core-test/src/test/java/com/azure/core/test/TestProxyTests.java
+++ b/sdk/core/azure-core-test/src/test/java/com/azure/core/test/TestProxyTests.java
@@ -181,7 +181,7 @@ public class TestProxyTests extends TestProxyTestBase {
         RecordedTestProxyData recordedTestProxyData = readDataFromFile();
         RecordedTestProxyData.TestProxyDataRecord record = recordedTestProxyData.getTestProxyDataRecords().get(0);
         // default sanitizers
-        assertEquals("https://REDACTED:3000/fr/path/1", record.getUri());
+        assertEquals("http://REDACTED:3000/fr/path/1", record.getUri());
         assertEquals(REDACTED, record.getHeaders().get("Ocp-Apim-Subscription-Key"));
         // custom sanitizers
         assertEquals(REDACTED, record.getResponse().get("modelId"));
@@ -248,7 +248,7 @@ public class TestProxyTests extends TestProxyTestBase {
         RecordedTestProxyData recordedTestProxyData = readDataFromFile();
         RecordedTestProxyData.TestProxyDataRecord record = recordedTestProxyData.getTestProxyDataRecords().get(0);
         // default regex sanitizers
-        assertEquals("https://REDACTED:3000/fr/path/2", record.getUri());
+        assertEquals("http://REDACTED:3000/fr/path/2", record.getUri());
 
         // user delegation sanitizers
         assertTrue(record.getResponse().get("Body").contains("<UserDelegationKey><SignedTid>REDACTED</SignedTid></UserDelegationKey>"));

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testBodyRegexRedactRecord.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testBodyRegexRedactRecord.json
@@ -1,11 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://REDACTED:3000/fr/path/2",
+      "RequestUri": "http://REDACTED:3000/fr/path/2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",
         "Connection": "keep-alive",
+        "Content-Type": "application/json",
         "User-Agent": "Java/11.0.9"
       },
       "RequestBody": null,

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testPlayBackWithRedaction.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testPlayBackWithRedaction.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://REDACTED:3000/fr/models",
+      "RequestUri": "http://REDACTED:3000/fr/models",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testPlayback.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testPlayback.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://REDACTED:3000/first/path",
+      "RequestUri": "http://REDACTED:3000/first/path",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testRecordWithRedaction.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testRecordWithRedaction.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://REDACTED:3000/fr/path/1",
+      "RequestUri": "http://REDACTED:3000/fr/path/1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",
@@ -19,7 +19,7 @@
         "Content-Type": "application/json",
         "Host": "localhost:3000",
         "Ocp-Apim-Subscription-Key": "REDACTED",
-        "traceparent": "00-18e2d72d3db49d1a4bae9e6a4c82dc96-8f32ab073c009f2a-00",
+        "traceparent": "00-3a459279cdd993bff30d9b9e27789b87-34b44715bd6d7e65-00",
         "User-Agent": "Java/11.0.9"
       },
       "ResponseBody": {


### PR DESCRIPTION
Fix default URL regex value for redacting and replacing only the domain part of the url and preserving http/https to the original request value.