### PR TITLE
Investigating exception handling for test proxy work

### DIFF
--- a/sdk/core/azure-core-test/src/main/java/com/azure/core/test/http/TestProxyPlaybackClient.java
+++ b/sdk/core/azure-core-test/src/main/java/com/azure/core/test/http/TestProxyPlaybackClient.java
@@ -5,6 +5,8 @@ package com.azure.core.test.http;
 
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpPipelineCallContext;
+import com.azure.core.http.HttpPipelineNextSyncPolicy;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.test.models.TestProxyRequestMatcher;
@@ -111,6 +113,15 @@ public class TestProxyPlaybackClient implements HttpClient {
         }
         TestProxyUtils.changeHeaders(request, xRecordingId, "playback");
         return client.send(request);
+    }
+
+    @Override
+    public HttpResponse sendSync(HttpRequest request, Context context) {
+        if (xRecordingId == null) {
+            throw new RuntimeException("Playback was not started before a request was sent.");
+        }
+        TestProxyUtils.changeHeaders(request, xRecordingId, "playback");
+        return client.sendSync(request, context);
     }
 
     /**

--- a/sdk/core/azure-core-test/src/main/java/com/azure/core/test/http/TestProxyTestServer.java
+++ b/sdk/core/azure-core-test/src/main/java/com/azure/core/test/http/TestProxyTestServer.java
@@ -3,6 +3,7 @@
 
 package com.azure.core.test.http;
 
+import com.azure.core.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
@@ -28,7 +29,10 @@ public class TestProxyTestServer implements Closeable {
             .port(3000)
             .route(routes -> routes
                 .get("/", (req, res) -> res.status(HttpResponseStatus.OK).sendString(Mono.just("hello world")))
-                .get("/first/path", (req, res) -> res.status(HttpResponseStatus.OK).sendString(Mono.just("first path")))
+                .get("/first/path", (req, res) -> {
+                    return res.status(HttpResponseStatus.CONFLICT)
+                        .addHeader("Content-Type", "application/json");
+                })
                 .get("/echoheaders", (req, res) -> {
                     for (Map.Entry<String, String> requestHeader : req.requestHeaders()) {
                         res.addHeader(requestHeader.getKey(), requestHeader.getValue());

--- a/sdk/core/azure-core-test/src/test/java/com/azure/core/test/implementation/RestProxyWithMockTests.java
+++ b/sdk/core/azure-core-test/src/test/java/com/azure/core/test/implementation/RestProxyWithMockTests.java
@@ -176,10 +176,14 @@ public class RestProxyWithMockTests extends RestProxyTests {
 
     @Host("http://localhost")
     @ServiceInterface(name = "ServiceErrorWithCharsetService")
-    interface ServiceErrorWithCharsetService {
+    public interface ServiceErrorWithCharsetService {
         @Get("/get")
         @ExpectedResponses({400})
         HttpBinJSON get();
+
+        @Get("/first/path")
+        @ExpectedResponses({400})
+        HttpBinJSON getPath();
     }
 
     @Test
@@ -429,7 +433,7 @@ public class RestProxyWithMockTests extends RestProxyTests {
         assertTrue(value.contains(expectedSubstring), "Expected \"" + value + "\" to contain \"" + expectedSubstring + "\".");
     }
 
-    private abstract static class SimpleMockHttpClient implements HttpClient {
+    public abstract static class SimpleMockHttpClient implements HttpClient {
 
         @Override
         public abstract Mono<HttpResponse> send(HttpRequest request);

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.serviceErrorOkHttpClient.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.serviceErrorOkHttpClient.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.serviceErrorWithMockHttpClient.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.serviceErrorWithMockHttpClient.json
@@ -1,0 +1,37 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://REDACTED/get",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",
+        "Connection": "keep-alive",
+        "User-Agent": "Java/11.0.9"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "10"
+      },
+      "ResponseBody": "Zmlyc3QgcGF0aA=="
+    }
+  ],
+  "Variables": {
+    "0": "2022-12-20T01:34:09.654867100Z",
+    "1": "playbacktest37304b",
+    "10": "2022-12-20T01:34:09.658552800Z",
+    "11": "198e2620-a55d-40c7-8635-4bf8385cc013",
+    "12": "2022-12-20T01:34:09.658552800Z",
+    "13": "playbacktest19443c",
+    "14": "2022-12-20T01:34:09.658552800Z",
+    "15": "bb309946-000b-4058-896f-853cd2271e94",
+    "2": "2022-12-20T01:34:09.657418600Z",
+    "3": "1d6ffce5-abce-481b-9db3-912fbf061764",
+    "4": "2022-12-20T01:34:09.658552800Z",
+    "5": "playbacktest125505",
+    "6": "2022-12-20T01:34:09.658552800Z",
+    "7": "618a5532-ec2d-4533-86c2-7c7a10b2eac0",
+    "8": "2022-12-20T01:34:09.658552800Z",
+    "9": "playbacktest39914b"
+  }
+}

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.serviceErrorWithUrlClient.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.serviceErrorWithUrlClient.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testRecordWithPath.json
+++ b/sdk/core/azure-core-test/src/test/resources/session-records/TestProxyTests.testRecordWithPath.json
@@ -1,0 +1,24 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://REDACTED/first/path",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",
+        "Connection": "keep-alive",
+        "User-Agent": "Java/17.0.1"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "0": "test01954",
+    "1": "2023-02-23T23:50:01.213501Z"
+  }
+}


### PR DESCRIPTION
# Scenario:

`ConfigurationClientTest.clearReadOnly` test expects to throw an exception of type `HttpResponseException.class`.
 This works correctly as expected when running in `RECORD` mode.
Fails when running in `PLAYBACK` mode and returns  `RuntimeException.class` instead.

## Findings so far:
### 1) **HttpURLConnectionHttpClient exception handling**
#### Test `testRecordWithPath()`  updated path to return _409 (error)_ from the server
- TestMode = Record
- Client = HttpURLConnectionHttpClient
- Test result:  assertThrows(**RuntimeException.class**, () -> pipeline.sendSync(request, Context.NONE));
    
> This should have returned `HttpResponseException.class`, as it was returning in the ConfigurationClientTest.clearReadOnly test.
The difference here is the underlying client in SDK tests is the runtime client(netty/okhttp etc)  the underlying client used by TestProxyTests is HttpURLConnectionHttpClient.
  
**Second test to confirm** this is when running `serviceErrorOkHttpClient()` we switch up the `URLClient ` with `OkHttpClient` and the test returns the expected HttpResponseException.

#### Test `serviceErrorOkHttpClient()` :
This test switches the URLClient with OkHttpClient, wrapped with Rest Interface.
- TestMode = Record
- Client = OkHttpClient
- Rest Interface integrated
- Test result: passes assertThrows(HttpResponseException.class, () -> service.get());
  
### 2) **RestProxy Integration**
To test this added several tests in TestProxyTests with integrated RestProxy service interfaces.
#### Test `serviceErrorWithUrlClient()`

- TestMode = Record
- Client = HttpURLConnectionHttpClient
- Rest Interface integrated
- Test result:  
    <img width="1056" alt="image" src="https://user-images.githubusercontent.com/16845631/221059489-5849cc2a-c689-44af-b6d7-7a44434e8db0.png">

#### Test `serviceErrorOkHttpClient()` :
This test switches the URLClient with OkHttpClient, wrapped with Rest Interface.
- TestMode = Record
- Client = OkHttpClient
- Rest Interface integrated
- Test result: passes assertThrows(HttpResponseException.class, () -> service.get());
    > recording entries are not written as there was no wire traffic? 👀 

#### Test `serviceErrorWithMockHttpClient()` 
- TestMode = Playback
- Client = PlaybackClient i.e HttpURLConnectionHttpClient
- Rest Interface integrated
- Test result :
    <img width="954" alt="image" src="https://user-images.githubusercontent.com/16845631/221060230-ab7bdbed-fc6a-4680-a07a-eb689f7552a7.png">
    > mocked recording entries to return 409

#### Test `serviceErrorWithMockHttpClient()` 
- TestMode = Record
- Client = MockHttpClient
- Rest Interface integrated
- Test result: passes assertThrows(HttpResponseException.class, () -> service.get());
    > recording entries are not written as there was no wire traffic? 👀 

### **From the above findings, it does seem like the HttpURLConnectionHttpClient returns the same result `RuntimeException` in `RECORD` and `PLAYBACK` and also `with/without RestProxy`.**